### PR TITLE
Add reserve rocket

### DIFF
--- a/src/components/Rocket/Rocket.css
+++ b/src/components/Rocket/Rocket.css
@@ -27,5 +27,5 @@ col {
 }
 
 .badge {
-  padding:6px;
+  padding: 6px;
 }

--- a/src/components/Rocket/Rocket.css
+++ b/src/components/Rocket/Rocket.css
@@ -25,3 +25,7 @@ col {
   padding: 0;
   margin: 0;
 }
+
+.badge {
+  padding:6px;
+}

--- a/src/components/Rocket/Rockets.js
+++ b/src/components/Rocket/Rockets.js
@@ -18,7 +18,7 @@ const Rockets = () => {
         <RocketItem
           key={rocket.id}
           id={rocket.id}
-          flickrImages={rocket.flickr_images}
+          flickrImages={rocket.flickrimages}
           name={rocket.name}
           description={rocket.description}
           reserved={rocket.reserved}

--- a/src/redux/rocketsSlice/rocketsSlice.js
+++ b/src/redux/rocketsSlice/rocketsSlice.js
@@ -13,13 +13,13 @@ export const fetchRockets = createAsyncThunk('rockets/fetchRockets', () => axios
   name: rocket.name,
   description: rocket.description,
   type: rocket.type,
-  flickr_images: rocket.flickr_images,
+  flickrimages: rocket.flickr_images,
   reserved: false,
 }))));
 
 export const reserveRocket = createAsyncThunk('rocket/reserveRocket', (id) => id);
 
-export const cancelReservation = createAsyncThunk('dragons/cancelReservation', (id) => id);
+export const cancelReservation = createAsyncThunk('rocket/cancelReservation', (id) => id);
 
 const rocketSlice = createSlice({
   name: 'rockets',
@@ -27,6 +27,14 @@ const rocketSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchRockets.pending, (state) => {
       state.isLoading = true;
+    });
+
+    builder.addCase(reserveRocket.fulfilled, (state, action) => {
+      const { id } = action.payload;
+      state.isLoading = false;
+      state.rockets = state.rockets.map((rocket) => (rocket.id === id
+        ? { ...rocket, reserved: true } : rocket));
+      state.error = '';
     });
 
     builder.addCase(fetchRockets.fulfilled, (state, action) => {


### PR DESCRIPTION
The following has been addressed in this pull request:

-When a user clicks the "Reserve rocket" button, action needs to be dispatched to update the store. You need to get the ID of the reserved rocket and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all rockets, but the selected rocket will have an extra key reserved with its value set to true.



